### PR TITLE
Update conda_dependencies

### DIFF
--- a/code/scoring/conda_dependencies.yml
+++ b/code/scoring/conda_dependencies.yml
@@ -25,7 +25,7 @@ dependencies:
 
 - pip:
     # Required packages for AzureML execution, history, and data preparation.
-  - azure-ml-api-sdk==0.1.0a11
+  - azureml-model-management-sdk==1.0.1b6.post1
   - azureml-sdk==1.0.74
   - scipy==1.3.1
   - scikit-learn==0.21.3

--- a/code/scoring/conda_dependencies.yml
+++ b/code/scoring/conda_dependencies.yml
@@ -25,7 +25,8 @@ dependencies:
 
 - pip:
     # Required packages for AzureML execution, history, and data preparation.
-  - azureml-sdk==1.0.72
+  - azure-ml-api-sdk==0.1.0a11
+  - azureml-sdk==1.0.74
   - scipy==1.3.1
   - scikit-learn==0.21.3
   - pandas==0.25.3


### PR DESCRIPTION
Adds back old PyPi package to fix the crash loop container for ACI/AKS deployments.