### PR TITLE
Fixed assignment bug for build_uri

### DIFF
--- a/code/register/register_model.py
+++ b/code/register/register_model.py
@@ -92,7 +92,9 @@ def main():
         if (builduri_base is not None):
             build_uri = builduri_base + build_id
             run.tag("BuildUri", value=build_uri)
-        register_aml_model(model_name, exp, run_id, build_id, build_uri)
+            register_aml_model(model_name, exp, run_id, build_id, build_uri)
+        else:
+            register_aml_model(model_name, exp, run_id, build_id)
 
 
 def model_already_registered(model_name, exp, run_id):


### PR DESCRIPTION
If the builduri_base is None, the build_uri would never been instantiated causing an error when calling register_aml_model(model_name, exp, run_id, build_id, build_uri). By adding the else statement, this is prevented.