### PR TITLE
Always run the pipeline evaluation step

### DIFF
--- a/.pipelines/diabetes_regression-ci-build-train.yml
+++ b/.pipelines/diabetes_regression-ci-build-train.yml
@@ -88,6 +88,7 @@ stages:
         PipelineParameters: '"ParameterAssignments": {"model_name": "$(MODEL_NAME)", "hyperparameter_alpha": "$(ALPHA)"}'
   - job: "Training_Run_Report"
     dependsOn: "Run_ML_Pipeline"
+    condition: always()
     displayName: "Determine if evaluation succeeded and new model is registered"
     pool:
         vmImage: 'ubuntu-latest'


### PR DESCRIPTION
Set the ci-build-train pipeline to always run the evaluation step (even if the pipeline is cancelled). This will cause the Azure Pipeline to log the reason for cancellation rather than just "silently failing".
#151 