### PR TITLE
Fixed and rearranged unit tests

### DIFF
--- a/.pipelines/azdo-base-pipeline.yml
+++ b/.pipelines/azdo-base-pipeline.yml
@@ -1,17 +1,11 @@
 steps:
-- task: PythonScript@0
-  inputs:
-    scriptSource: inline
-    script: set -eux
-            flake8 --output-file=lint-testresults.xml --format junit-xml
+- script: |   
+   flake8 --output-file=lint-testresults.xml --format junit-xml
   displayName: 'Run lint tests'
 
-- task: PythonScript@0
-  inputs:
-    scriptSource: inline
-    script: set -eux 
-            python -m pytest tests/unit --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml
-  displayName: 'Test with pytest'
+- script: |   
+   python -m pytest tests/unit --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml
+  displayName: 'Run unit tests'
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/.pipelines/azdo-base-pipeline.yml
+++ b/.pipelines/azdo-base-pipeline.yml
@@ -4,7 +4,7 @@ steps:
   displayName: 'Run lint tests'
 
 - script: |   
-   python -m pytest tests/unit --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml
+   python -m pytest . --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml
   displayName: 'Run unit tests'
 
 - task: PublishTestResults@2

--- a/.pipelines/azdo-base-pipeline.yml
+++ b/.pipelines/azdo-base-pipeline.yml
@@ -1,7 +1,17 @@
 steps:
-- script: |
-    ./lint-and-test.sh
-  displayName: 'Linting & unit tests'
+- task: PythonScript@0
+  inputs:
+    scriptSource: inline
+    script: set -eux
+            flake8 --output-file=lint-testresults.xml --format junit-xml
+  displayName: 'Run lint tests'
+
+- task: PythonScript@0
+  inputs:
+    scriptSource: inline
+    script: set -eux 
+            python -m pytest tests/unit --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml
+  displayName: 'Test with pytest'
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This reference architecture shows how to implement continuous integration (CI), 
 2. Once the Azure DevOps build pipeline is triggered, it performs code quality checks, data sanity tests, unit tests, builds an [Azure ML Pipeline](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-ml-pipelines) and publishes it in an [Azure ML Service Workspace](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-azure-machine-learning-architecture#workspace).
 3. The [Azure ML Pipeline](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-ml-pipelines) is triggered once the Azure DevOps build pipeline completes. All the tasks in this pipeline runs on Azure ML Compute. Following are the tasks in this pipeline:
 
-    - **Train Model** task executes model training script on Azure ML Compute. It outputs a [model](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-azure-machine-learning-architecture#model) file which is stored in the [run history](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-azure-machine-learning-architecture#run).
+    - **Train Model** task executes model training script on Azure ML Compute. It outputs a [model](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-azure-machine-learning-architecture#models) file which is stored in the [run history](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-azure-machine-learning-architecture#runs).
 
     - **Evaluate Model** task evaluates the performance of the newly trained model with the model in production. If the new model performs better than the production model, the following steps are executed. If not, they will be skipped.
 

--- a/data/data_test.py
+++ b/data/data_test.py
@@ -35,7 +35,7 @@ def get_absPath(filename):
     path = os.path.abspath(
         os.path.join(
             os.path.dirname(
-                __file__), os.path.pardir, os.path.pardir, "data", filename
+                __file__), os.path.pardir, "data", filename
         )
     )
     return path

--- a/diabetes_regression/ci_dependencies.yml
+++ b/diabetes_regression/ci_dependencies.yml
@@ -25,4 +25,3 @@ dependencies:
       - flake8==3.7.9
       - flake8_formatter_junit_xml==0.0.6
       - azure-cli==2.0.81
-      - tox==3.14.3

--- a/diabetes_regression/training/test_train.py
+++ b/diabetes_regression/training/test_train.py
@@ -25,4 +25,3 @@ def test_train_model():
 
     preds = reg.predict([[1], [2]])
     np.testing.assert_equal(preds, [9.93939393939394, 9.03030303030303])
-    

--- a/diabetes_regression/training/test_train.py
+++ b/diabetes_regression/training/test_train.py
@@ -25,3 +25,4 @@ def test_train_model():
 
     preds = reg.predict([[1], [2]])
     np.testing.assert_equal(preds, [9.93939393939394, 9.03030303030303])
+    

--- a/diabetes_regression/training/test_train.py
+++ b/diabetes_regression/training/test_train.py
@@ -15,8 +15,13 @@ def test_train_model():
     run = Mock(Run)
     reg = train_model(run, data, alpha=1.2)
 
-    run.log.assert_called_with("mse", 0.029843893480257067,
-                               description='Mean squared error metric')
+    _, call2 = run.log.call_args_list
+    nameValue, descriptionDict = call2
+    name, value = nameValue
+    description = descriptionDict['description']
+    assert (name == 'mse')
+    np.testing.assert_almost_equal(value, 0.029843893480257067)
+    assert (description == 'Mean squared error metric')
 
     preds = reg.predict([[1], [2]])
     np.testing.assert_equal(preds, [9.93939393939394, 9.03030303030303])

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -38,7 +38,3 @@ BUILD_BUILDID is a variable used to uniquely identify the ML pipeline between th
 set to the current build number. In a local environment, we can use a command such as
 `uuidgen` so set a different random identifier on each run, ensuring there are 
 no collisions.
-
-### Local testing
-
-Before committing, run `tox` to execute linter and unit test checks.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -67,7 +67,7 @@ be naming collisions with resources that require unique names like azure blob
 storage and registry DNS naming. Make sure to give a unique value to the
 BASE_NAME variable (e.g. MyUniqueML), so that the created resources will have
 unique names (e.g. MyUniqueMLamlcr, MyUniqueML-AML-KV, etc.). The length of
-the BASE_NAME value should not exceed 10 characters. 
+the BASE_NAME value should not exceed 10 characters and it should contain numbers and letters only. 
 
 The **RESOURCE_GROUP** parameter is used as the name for the resource group that will hold the Azure resources for the solution. If providing an existing AML Workspace, set this value to the corresponding resource group name.
 
@@ -115,11 +115,11 @@ Having done that, run the pipeline:
 
 ![iac run](./images/run-iac-pipeline.png)
 
-Check out the newly created resources in the [Azure Portal](portal.azure.com):
+Check out the newly created resources in the [Azure Portal](https://portal.azure.com):
 
 ![created resources](./images/created-resources.png)
 
-(Optional) To remove the resources created for this project you can use the [/environment_setup/iac-remove-environment.yml](../environment_setup/iac-remove-environment.yml) definition or you can just delete the resource group in the [Azure Portal](portal.azure.com).
+(Optional) To remove the resources created for this project you can use the [/environment_setup/iac-remove-environment.yml](../environment_setup/iac-remove-environment.yml) definition or you can just delete the resource group in the [Azure Portal](https://portal.azure.com).
 
 **Note:** The training ML pipeline uses a [sample diabetes dataset](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_diabetes.html) as training data. If you want to use your own dataset, you need to [create and register a datastore](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-access-data#azure-machine-learning-studio) in your ML workspace and upload the datafile (e.g. [diabetes.csv](./data/diabetes.csv)) to the corresponding blob container. You can also define a datastore in the ML Workspace with [az cli](https://docs.microsoft.com/en-us/cli/azure/ext/azure-cli-ml/ml/datastore?view=azure-cli-latest#ext-azure-cli-ml-az-ml-datastore-attach-blob). 
 You'll also need to configure DATASTORE_NAME and DATAFILE_NAME variables in ***devopsforai-aml-vg*** variable group.
@@ -162,8 +162,7 @@ Once the pipeline is finished, explore the execution result:
 
 ![build](./images/multi-stage-aci.png)
 
-and check out the published training pipeline in the **mlops-AML-WS** workspace in
-[Azure Portal](https://ms.portal.azure.com/):
+and check out the published training pipeline in the **mlops-AML-WS** workspace in [Azure Portal](https://portal.azure.com/):
 
 ![training pipeline](./images/training-pipeline.png)
 

--- a/lint-and-test.sh
+++ b/lint-and-test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -eux
-flake8 --output-file=lint-testresults.xml --format junit-xml
-python -m pytest tests/unit --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,0 @@
-[flake8]
-# ignore obsolete warning
-ignore = W503
-exclude = .git,__pycache__,.venv,.tox,**/site-packages/**/*.py,**/lib/**.py,**/bin/**.py
-
-[pytest]
-junit_family = legacy


### PR DESCRIPTION
- Fixed test_train_model test in code_test.py
- Renamed code_test.py to train_test.py
- Moved train_test.py under diabetes_regression directory
- Moved data_test.py under data directory
- Added lint and unit test tasks to azdo-base-pipeline.yml
- Deleted lint-and-test.sh and tox.ini