### PR TITLE
run unit tests in any case

### DIFF
--- a/.pipelines/azdo-base-pipeline.yml
+++ b/.pipelines/azdo-base-pipeline.yml
@@ -5,6 +5,7 @@ steps:
 
 - script: |   
    python -m pytest . --cov=diabetes_regression --cov-report=html --cov-report=xml --junitxml=unit-testresults.xml
+  condition: succeededOrFailed()
   displayName: 'Run unit tests'
 
 - task: PublishTestResults@2


### PR DESCRIPTION
Just a condition to run unit tests even in the case if linting is not completed successfully. Potentially, it can reduce number of pipeline calls because devs will be able to see all problems at the same time rather than find them one by one