### PR TITLE
Use correct parameter names in web app deploy

### DIFF
--- a/.pipelines/diabetes_regression-ci-build-train.yml
+++ b/.pipelines/diabetes_regression-ci-build-train.yml
@@ -180,7 +180,8 @@ stages:
       inputs:
         azureSubscription: 'AzureResourceConnection'
         appName: '$(WEBAPP_DEPLOYMENT_NAME)'
-        containers: '$(IMAGE_LOCATION)'
+        resourceGroupName: '$(RESOURCE_GROUP)'
+        imageName: '$(IMAGE_LOCATION)'
     - task: AzureCLI@1
       displayName: 'Smoke test'
       inputs:


### PR DESCRIPTION
It is not clear from the docs, but looking at the source code for the AzureWebAppContainer task it need a resource group and an image name (as opposed to container name). These parameters deploy successfully for me.

I'm not sure about the azureSubscription value, it might not be needed but I've left it as it was.