### PR TITLE
ci-build-train pipeline condition fix

### DIFF
--- a/.pipelines/diabetes_regression-ci-build-train.yml
+++ b/.pipelines/diabetes_regression-ci-build-train.yml
@@ -43,7 +43,7 @@ stages:
 
 - stage: 'Trigger_AML_Pipeline'
   displayName: 'Train model'
-  condition: not(variables['MODEL_BUILD_ID'])
+  condition: and(succeeded(), not(variables['MODEL_BUILD_ID']))
   jobs:
   - job: "Get_Pipeline_ID"
     condition: and(succeeded(), eq(coalesce(variables['auto-trigger-training'], 'true'), 'true'))


### PR DESCRIPTION
Fixing regression introduced in #207 - don't continue pipeline on lint/unit test errors.