### PR TITLE
Canary pipeline fixes

### DIFF
--- a/.pipelines/abtest.yml
+++ b/.pipelines/abtest.yml
@@ -18,6 +18,7 @@ trigger:
     - ml_service/util/smoke_test_scoring_service.py
 
 variables:
+- template: diabetes_regression-variables-template.yml
 - group: 'devopsforai-aml-vg'
 - name: 'helmVersion'
   value: 'v3.0.1'

--- a/.pipelines/abtest.yml
+++ b/.pipelines/abtest.yml
@@ -21,7 +21,7 @@ variables:
 - template: diabetes_regression-variables-template.yml
 - group: 'devopsforai-aml-vg'
 - name: 'helmVersion'
-  value: 'v3.0.1'
+  value: 'v3.1.1'
 - name: 'helmDownloadURL'
   value: 'https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz'
 - name: 'blueReleaseName'

--- a/charts/abtest-model/templates/deployment.yaml
+++ b/charts/abtest-model/templates/deployment.yaml
@@ -27,5 +27,4 @@ spec:
           containerPort: 5001
         - name: probe
           containerPort: 8086
-      imagePullSecrets:
-        - name: aks-secret     
+


### PR DESCRIPTION
- Use the variable template so we don't have to manually define MODEL_NAME and MODEL_VERSION
- Upgrade helm version to 3.1.1 to fix some issues
- Enable ACR authentication using service principals rather than a manual secret