### PR TITLE
Use yaml based pipeline, CLI, ServerTask for ML continuous integration

### DIFF
--- a/.azureml/diabetes_regression.runconfig
+++ b/.azureml/diabetes_regression.runconfig
@@ -1,0 +1,148 @@
+# The script to run.
+script:
+# The arguments to the script file.
+arguments:
+- --data-folder
+- DatasetConsumptionConfig:mnist
+# The name of the compute target to use for this run.
+target: cpu-cluster
+# Framework to execute inside. Allowed values are "Python" ,  "PySpark", "CNTK",  "TensorFlow", and "PyTorch".
+framework: python
+# Communicator for the given framework. Allowed values are "None" ,  "ParameterServer", "OpenMpi", and "IntelMpi".
+communicator: None
+# Maximum allowed duration for the run.
+maxRunDurationSeconds:
+# Number of nodes to use for running job.
+nodeCount: 4
+# Environment details.
+environment:
+# Environment name
+  name: conda-env
+# Environment version
+  version:
+# Environment variables set for the run.
+  environmentVariables:
+    EXAMPLE_ENV_VAR: EXAMPLE_VALUE
+# Python details
+  python:
+# user_managed_dependencies=True indicates that the environmentwill be user managed. False indicates that AzureML willmanage the user environment.
+    userManagedDependencies: false
+# The python interpreter path
+    interpreterPath: python
+# Path to the conda dependencies file to use for this run. If a project
+# contains multiple programs with different sets of dependencies, it may be
+# convenient to manage those environments with separate files.
+    condaDependenciesFile: train_dependencies.yml
+# The base conda environment used for incremental environment creation.
+    baseCondaEnvironment:
+# Docker details
+  docker:
+# Set True to perform this run inside a Docker container.
+    enabled: true
+# Base image used for Docker-based runs. Mutually exclusive with base_dockerfile.
+    baseImage: mcr.microsoft.com/azureml/base:intelmpi2018.3-ubuntu16.04
+# Base Dockerfile used for Docker-based runs. Mutually exclusive with base_image
+    baseDockerfile:
+# Set False if necessary to work around shared volume bugs.
+    sharedVolumes: true
+# Shared memory size for Docker container. Default is 2g.
+    shmSize: 2g
+# Extra arguments to the Docker run command.
+    arguments: []
+# Image registry that contains the base image.
+    baseImageRegistry:
+# DNS name or IP address of azure container registry(ACR)
+      address:
+# The username for ACR
+      username:
+# The password for ACR
+      password:
+# Spark details
+  spark:
+# List of spark repositories.
+    repositories: []
+# The packages to use.
+    packages: []
+# Whether to precache the packages.
+    precachePackages: true
+# Databricks details
+  databricks:
+# List of maven libraries.
+    mavenLibraries: []
+# List of PyPi libraries
+    pypiLibraries: []
+# List of RCran libraries
+    rcranLibraries: []
+# List of JAR libraries
+    jarLibraries: []
+# List of Egg libraries
+    eggLibraries: []
+# Inferencing stack version
+  inferencingStackVersion:
+# History details.
+history:
+# Enable history tracking -- this allows status, logs, metrics, and outputs
+# to be collected for a run.
+  outputCollection: true
+# Whether to take snapshots for history.
+  snapshotProject: true
+# Directories to sync with FileWatcher.
+  directoriesToWatch:
+  - logs
+# Spark configuration details.
+spark:
+# The Spark configuration.
+  configuration:
+    spark.app.name: Azure ML Experiment
+    spark.yarn.maxAppAttempts: 1
+# HDI details.
+hdi:
+# Yarn deploy mode. Options are cluster and client.
+  yarnDeployMode: cluster
+# Tensorflow details.
+tensorflow:
+# The number of worker tasks.
+  workerCount: 1
+# The number of parameter server tasks.
+  parameterServerCount: 1
+# Mpi details.
+mpi:
+# When using MPI, number of processes per node.
+  processCountPerNode: 1
+# data reference configuration details
+dataReferences: {}
+# The configuration details for data.
+data:
+  mnist:
+# Data Location
+    dataLocation:
+# the Dataset used for this run.
+      dataset:
+# Id of the dataset.
+        id: ed4b4117-8eec-4a5f-afb6-481bd5ef0017
+# the DataPath used for this run.
+      datapath:
+# Whether to create new folder.
+    createOutputDirectories: false
+# The mode to handle
+    mechanism: mount
+# Point where the data is download or mount or upload.
+    environmentVariableName: mnist
+# relative path where the data is download or mount or upload.
+    pathOnCompute:
+# Whether to overwrite the data if existing.
+    overwrite: false
+# Project share datastore reference.
+sourceDirectoryDataStore:
+# AmlCompute details.
+amlcompute:
+# VM size of the Cluster to be created.Allowed values are Azure vm sizes.The list of vm sizes is available in 'https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
+  vmSize:
+# VM priority of the Cluster to be created. Allowed values are:"dedicated" , "lowpriority".
+  vmPriority:
+# A bool that indicates if the cluster has to be retained after job completion.
+  retainCluster: false
+# Name of the cluster to be created. If not specified, runId will be used as cluster name.
+  name:
+# Maximum number of nodes in the AmlCompute cluster to be created. Minimum number of nodes will always be set to 0.
+  clusterMaxNodeCount:

--- a/.azureml/docker
+++ b/.azureml/docker
@@ -1,0 +1,127 @@
+# The script to run.
+script: train.py
+# The arguments to the script file.
+arguments: []
+# The name of the compute target to use for this run.
+target: local
+# Framework to execute inside. Allowed values are "Python" ,  "PySpark", "CNTK",  "TensorFlow", and "PyTorch".
+framework: Python
+# Communicator for the given framework. Allowed values are "None" ,  "ParameterServer", "OpenMpi", and "IntelMpi".
+communicator: None
+# Maximum allowed duration for the run.
+maxRunDurationSeconds:
+# Number of nodes to use for running job.
+nodeCount: 1
+# Environment details.
+environment:
+# Environment name
+  name:
+# Environment version
+  version:
+# Environment variables set for the run.
+  environmentVariables:
+    EXAMPLE_ENV_VAR: EXAMPLE_VALUE
+# Python details
+  python:
+# user_managed_dependencies=True indicates that the environmentwill be user managed. False indicates that AzureML willmanage the user environment.
+    userManagedDependencies: false
+# The python interpreter path
+    interpreterPath: python
+# Path to the conda dependencies file to use for this run. If a project
+# contains multiple programs with different sets of dependencies, it may be
+# convenient to manage those environments with separate files.
+    condaDependenciesFile: .azureml/conda_dependencies.yml
+# The base conda environment used for incremental environment creation.
+    baseCondaEnvironment:
+# Docker details
+  docker:
+# Set True to perform this run inside a Docker container.
+    enabled: true
+# Base image used for Docker-based runs. Mutually exclusive with base_dockerfile.
+    baseImage: mcr.microsoft.com/azureml/base:intelmpi2018.3-ubuntu16.04
+# Base Dockerfile used for Docker-based runs. Mutually exclusive with base_image
+    baseDockerfile:
+# Set False if necessary to work around shared volume bugs.
+    sharedVolumes: true
+# Shared memory size for Docker container. Default is 2g.
+    shmSize: 2g
+# Extra arguments to the Docker run command.
+    arguments: []
+# Image registry that contains the base image.
+    baseImageRegistry:
+# DNS name or IP address of azure container registry(ACR)
+      address:
+# The username for ACR
+      username:
+# The password for ACR
+      password:
+# Spark details
+  spark:
+# List of spark repositories.
+    repositories: []
+# The packages to use.
+    packages: []
+# Whether to precache the packages.
+    precachePackages: true
+# Databricks details
+  databricks:
+# List of maven libraries.
+    mavenLibraries: []
+# List of PyPi libraries
+    pypiLibraries: []
+# List of RCran libraries
+    rcranLibraries: []
+# List of JAR libraries
+    jarLibraries: []
+# List of Egg libraries
+    eggLibraries: []
+# Inferencing stack version
+  inferencingStackVersion:
+# History details.
+history:
+# Enable history tracking -- this allows status, logs, metrics, and outputs
+# to be collected for a run.
+  outputCollection: true
+# Whether to take snapshots for history.
+  snapshotProject: true
+# Directories to sync with FileWatcher.
+  directoriesToWatch:
+  - logs
+# Spark configuration details.
+spark:
+# The Spark configuration.
+  configuration:
+    spark.app.name: Azure ML Experiment
+    spark.yarn.maxAppAttempts: 1
+# HDI details.
+hdi:
+# Yarn deploy mode. Options are cluster and client.
+  yarnDeployMode: cluster
+# Tensorflow details.
+tensorflow:
+# The number of worker tasks.
+  workerCount: 1
+# The number of parameter server tasks.
+  parameterServerCount: 1
+# Mpi details.
+mpi:
+# When using MPI, number of processes per node.
+  processCountPerNode: 1
+# data reference configuration details
+dataReferences: {}
+# The configuration details for data.
+data: {}
+# Project share datastore reference.
+sourceDirectoryDataStore:
+# AmlCompute details.
+amlcompute:
+# VM size of the Cluster to be created.Allowed values are Azure vm sizes.The list of vm sizes is available in 'https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
+  vmSize:
+# VM priority of the Cluster to be created. Allowed values are:"dedicated" , "lowpriority".
+  vmPriority:
+# A bool that indicates if the cluster has to be retained after job completion.
+  retainCluster: false
+# Name of the cluster to be created. If not specified, runId will be used as cluster name.
+  name:
+# Maximum number of nodes in the AmlCompute cluster to be created. Minimum number of nodes will always be set to 0.
+  clusterMaxNodeCount:

--- a/.azureml/local
+++ b/.azureml/local
@@ -1,0 +1,127 @@
+# The script to run.
+script: train.py
+# The arguments to the script file.
+arguments: []
+# The name of the compute target to use for this run.
+target: local
+# Framework to execute inside. Allowed values are "Python" ,  "PySpark", "CNTK",  "TensorFlow", and "PyTorch".
+framework: Python
+# Communicator for the given framework. Allowed values are "None" ,  "ParameterServer", "OpenMpi", and "IntelMpi".
+communicator: None
+# Maximum allowed duration for the run.
+maxRunDurationSeconds:
+# Number of nodes to use for running job.
+nodeCount: 1
+# Environment details.
+environment:
+# Environment name
+  name:
+# Environment version
+  version:
+# Environment variables set for the run.
+  environmentVariables:
+    EXAMPLE_ENV_VAR: EXAMPLE_VALUE
+# Python details
+  python:
+# user_managed_dependencies=True indicates that the environmentwill be user managed. False indicates that AzureML willmanage the user environment.
+    userManagedDependencies: false
+# The python interpreter path
+    interpreterPath: python
+# Path to the conda dependencies file to use for this run. If a project
+# contains multiple programs with different sets of dependencies, it may be
+# convenient to manage those environments with separate files.
+    condaDependenciesFile: .azureml/conda_dependencies.yml
+# The base conda environment used for incremental environment creation.
+    baseCondaEnvironment:
+# Docker details
+  docker:
+# Set True to perform this run inside a Docker container.
+    enabled: false
+# Base image used for Docker-based runs. Mutually exclusive with base_dockerfile.
+    baseImage: mcr.microsoft.com/azureml/base:intelmpi2018.3-ubuntu16.04
+# Base Dockerfile used for Docker-based runs. Mutually exclusive with base_image
+    baseDockerfile:
+# Set False if necessary to work around shared volume bugs.
+    sharedVolumes: true
+# Shared memory size for Docker container. Default is 2g.
+    shmSize: 2g
+# Extra arguments to the Docker run command.
+    arguments: []
+# Image registry that contains the base image.
+    baseImageRegistry:
+# DNS name or IP address of azure container registry(ACR)
+      address:
+# The username for ACR
+      username:
+# The password for ACR
+      password:
+# Spark details
+  spark:
+# List of spark repositories.
+    repositories: []
+# The packages to use.
+    packages: []
+# Whether to precache the packages.
+    precachePackages: true
+# Databricks details
+  databricks:
+# List of maven libraries.
+    mavenLibraries: []
+# List of PyPi libraries
+    pypiLibraries: []
+# List of RCran libraries
+    rcranLibraries: []
+# List of JAR libraries
+    jarLibraries: []
+# List of Egg libraries
+    eggLibraries: []
+# Inferencing stack version
+  inferencingStackVersion:
+# History details.
+history:
+# Enable history tracking -- this allows status, logs, metrics, and outputs
+# to be collected for a run.
+  outputCollection: true
+# Whether to take snapshots for history.
+  snapshotProject: true
+# Directories to sync with FileWatcher.
+  directoriesToWatch:
+  - logs
+# Spark configuration details.
+spark:
+# The Spark configuration.
+  configuration:
+    spark.app.name: Azure ML Experiment
+    spark.yarn.maxAppAttempts: 1
+# HDI details.
+hdi:
+# Yarn deploy mode. Options are cluster and client.
+  yarnDeployMode: cluster
+# Tensorflow details.
+tensorflow:
+# The number of worker tasks.
+  workerCount: 1
+# The number of parameter server tasks.
+  parameterServerCount: 1
+# Mpi details.
+mpi:
+# When using MPI, number of processes per node.
+  processCountPerNode: 1
+# data reference configuration details
+dataReferences: {}
+# The configuration details for data.
+data: {}
+# Project share datastore reference.
+sourceDirectoryDataStore:
+# AmlCompute details.
+amlcompute:
+# VM size of the Cluster to be created.Allowed values are Azure vm sizes.The list of vm sizes is available in 'https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
+  vmSize:
+# VM priority of the Cluster to be created. Allowed values are:"dedicated" , "lowpriority".
+  vmPriority:
+# A bool that indicates if the cluster has to be retained after job completion.
+  retainCluster: false
+# Name of the cluster to be created. If not specified, runId will be used as cluster name.
+  name:
+# Maximum number of nodes in the AmlCompute cluster to be created. Minimum number of nodes will always be set to 0.
+  clusterMaxNodeCount:

--- a/.azureml/train_dependencies.yml
+++ b/.azureml/train_dependencies.yml
@@ -1,0 +1,40 @@
+# Conda environment specification. The dependencies defined in this file will
+# be automatically provisioned for managed runs. These include runs against
+# the localdocker, remotedocker, and cluster compute targets.
+
+# Note that this file is NOT used to automatically manage dependencies for the
+# local compute target. To provision these dependencies locally, run:
+# conda env update --file conda_dependencies.yml
+
+# Details about the Conda environment file format:
+# https://conda.io/docs/using/envs.html#create-environment-file-by-hand
+
+# For managing Spark packages and configuration, see spark_dependencies.yml.
+# Version of this configuration file's structure and semantics in AzureML.
+# This directive is stored in a comment to preserve the Conda file structure.
+# [AzureMlVersion] = 2
+
+name: diabetes_regression_training_env
+dependencies:
+  # The python interpreter version.
+  # Currently Azure ML Workbench only supports 3.5.2 and later.
+  - python=3.7.5
+  # Required by azureml-defaults, installed separately through Conda to
+  # get a prebuilt version and not require build tools for the install.
+  - psutil=5.6 #latest
+
+  - pip:
+      # Required packages for AzureML execution, history, and data preparation.
+      - azureml-model-management-sdk==1.0.1b6.post1
+      - azureml-sdk==1.0.74
+      - scipy==1.3.1
+      - scikit-learn==0.22
+      - pandas==0.25.3
+      - numpy==1.17.3
+      - joblib==0.14.0
+      - gunicorn==19.9.0
+      - flask==1.1.1
+      - inference-schema[numpy-support]
+      - azure
+      - azure-storage-blob
+      - azureml-dataprep

--- a/.pipelines/diabetes_regression-ci-yml-pipeline.yml
+++ b/.pipelines/diabetes_regression-ci-yml-pipeline.yml
@@ -1,0 +1,90 @@
+# Continuous Integration (CI) pipeline that orchestrates the training, evaluation, registration, deployment, and testing of the diabetes_regression model.
+
+resources:
+  containers:
+  - container: mlops
+    image: mcr.microsoft.com/mlops/python:latest
+
+pr: none
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - diabetes_regression/
+
+variables:
+- template: diabetes_regression-variables-template.yml
+- group: devopsforai-aml-vg
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+- stage: 'Continuous_Integration'
+  displayName: 'Continuous Integration'
+  condition: not(variables['MODEL_BUILD_ID'])
+  variables:
+    BUILD_URI: '$(SYSTEM.COLLECTIONURI)$(SYSTEM.TEAMPROJECT)/_build/results?buildId=$(BUILD.BUILDID)'
+  jobs:
+  - job: "Preparation"
+    displayName: "Preparation"
+    container: mlops
+    timeoutInMinutes: 0
+    steps:
+    - template: code-quality-template.yml
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: 'az extension add -n azure-cli-ml'
+      displayName: 'Install AzureML CLI'
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: 'az ml computetarget create amlcompute -n cpu-cluster --max-nodes 4 -s STANDARD_DS12_V2'
+      displayName: 'Create compute if nonexisted'
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: 'az ml datastore upload -n workspaceblobstore -p ./data -u diabetes_regression_training_data'
+      displayName: 'Upload to datastore'
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: 'az ml dataset register -f ./dataset.json'
+      displayName: 'Register dataset'
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: |
+          set -e # fail on error
+          AMLPIPELINEID=$(az ml pipeline create -n $(TRAINING_PIPELINE_NAME) -y ./.pipelines/ml_training_pipeline.yml --query Id -o tsv)
+          echo "##vso[task.setvariable variable=AMLPIPELINEID;isOutput=true]$AMLPIPELINEID"
+      name: 'Publish_ML_Pipeline'
+      displayName: 'Publish ML pipeline'
+  - job: "Run_ML_Pipeline"
+    displayName: "Trigger ML Training Pipeline"
+    dependsOn: "Preparation"
+    timeoutInMinutes: 0
+    pool: server
+    variables:
+      AMLPIPELINE_ID: $[ dependencies.Preparation.outputs['Publish_ML_Pipeline.AMLPIPELINEID'] ]
+    steps:
+    - task: ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask@0
+      displayName: 'Invoke ML pipeline'
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        PipelineId: '$(AMLPIPELINE_ID)'
+        ExperimentName: '$(EXPERIMENT_NAME)'
+        PipelineParameters: '"ParameterAssignments": {"model_name": "$(MODEL_NAME)"}, "tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'

--- a/.pipelines/diabetes_regression-ci-yml-pipeline.yml
+++ b/.pipelines/diabetes_regression-ci-yml-pipeline.yml
@@ -12,7 +12,9 @@ trigger:
     - master
   paths:
     include:
-    - diabetes_regression/
+    - data/
+    - source/
+    - .pipelines/
 
 variables:
 - template: diabetes_regression-variables-template.yml

--- a/.pipelines/ml_training_pipeline.yml
+++ b/.pipelines/ml_training_pipeline.yml
@@ -1,0 +1,69 @@
+pipeline:
+    name: DiabetesTrainingPipeline
+    parameters:
+        model_name:
+            type: string
+            default: "model_from_pipeline_test"
+        model_folder:
+            type: string
+            default: "model_folder"
+    data_references:
+        diabetes_training_data:
+            datastore: workspaceblobstore
+            path_on_datastore: diabetes_regression_training_data/diabetes.csv
+    default_compute: cpu-cluster
+    steps:
+        Step1:
+            runconfig: "../.azureml/diabetes_regression.runconfig"
+            type: "PythonScriptStep"
+            name: "Train Model"
+            script_name: "training/train.py"
+            allow_reuse: False
+            source_directory: "../source"
+            arguments:
+                - "--source_data"
+                - input:sample_data
+                - "--model_name"
+                - parameter:model_name
+                - "--step_output"
+                - output:pipeline_data
+            parameters:
+                model_name:
+                    source: model_name
+            inputs:
+                sample_data:
+                    source: diabetes_training_data
+                    bind_mode: mount
+            outputs:
+                pipeline_data:
+                    destination: pipeline_data
+                    datastore: workspaceblobstore
+                    bind_mode: mount
+                    path_on_compute: "output"
+                    overwrite: true
+        Step2:
+            runconfig: "../.azureml/diabetes_regression.runconfig"
+            type: "PythonScriptStep"
+            name: "Register Model"
+            script_name: "register/eval_register.py"
+            allow_reuse: False
+            source_directory: "../source"
+            arguments:
+                - "--model_name"
+                - parameter:model_name
+                - "--step_input"
+                - input:pipeline_data
+                - "--model_upload_folder"
+                - parameter:model_folder
+            parameters:
+                model_name:
+                    source: model_name
+                model_folder:
+                    source: model_folder
+            inputs:
+                pipeline_data:
+                    source: pipeline_data
+                    datastore: workspaceblobstore
+                    bind_mode: mount
+                    path_on_compute: "input"
+                    overwrite: true

--- a/.pipelines/ml_training_pipeline.yml
+++ b/.pipelines/ml_training_pipeline.yml
@@ -14,12 +14,12 @@ pipeline:
     default_compute: cpu-cluster
     steps:
         Step1:
-            runconfig: "../.azureml/diabetes_regression.runconfig"
+            runconfig: ".azureml/diabetes_regression.runconfig"
             type: "PythonScriptStep"
             name: "Train Model"
             script_name: "training/train.py"
             allow_reuse: False
-            source_directory: "../source"
+            source_directory: "source"
             arguments:
                 - "--source_data"
                 - input:sample_data
@@ -42,12 +42,12 @@ pipeline:
                     path_on_compute: "output"
                     overwrite: true
         Step2:
-            runconfig: "../.azureml/diabetes_regression.runconfig"
+            runconfig: ".azureml/diabetes_regression.runconfig"
             type: "PythonScriptStep"
             name: "Register Model"
             script_name: "register/eval_register.py"
             allow_reuse: False
-            source_directory: "../source"
+            source_directory: "source"
             arguments:
                 - "--model_name"
                 - parameter:model_name

--- a/dataset.json
+++ b/dataset.json
@@ -1,0 +1,21 @@
+{
+  "datasetType": "Tabular",
+  "parameters": {
+    "path": [
+      {
+        "datastoreName": "workspaceblobstore",
+        "relativePath": "diabetes_regression_training_data/diabetes.csv"
+      }
+    ],
+    "sourceType": "delimited_files"
+  },
+  "registration": {
+    "createNewVersion": true,
+    "description": "diabetes training dataset",
+    "name": "diabetes-dataset",
+    "tags": {
+      "sample-tag": "diabetes"
+    }
+  },
+  "schemaVersion": 1
+}

--- a/source/register/eval_register.py
+++ b/source/register/eval_register.py
@@ -1,0 +1,153 @@
+"""
+Copyright (C) Microsoft Corporation. All rights reserved.​
+ ​
+Microsoft Corporation (“Microsoft”) grants you a nonexclusive, perpetual,
+royalty-free right to use, copy, and modify the software code provided by us
+("Software Code"). You may not sublicense the Software Code or any use of it
+(except to your affiliates and to vendors to perform work on your behalf)
+through distribution, network access, service agreement, lease, rental, or
+otherwise. This license does not purport to express any claim of ownership over
+data you may have shared with Microsoft in the creation of the Software Code.
+Unless applicable law gives you more rights, Microsoft reserves all other
+rights not expressly granted herein, whether by implication, estoppel or
+otherwise. ​
+ ​
+THE SOFTWARE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+MICROSOFT OR ITS LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THE SOFTWARE CODE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+import os
+import sys
+import argparse
+import joblib
+from azureml.core import Run
+from util.model_helper import get_latest_model
+
+_MODEL_METRIC_EVAL_KEY = 'mse'
+
+
+def evaluate(model=None, new_model_mse=0):
+    if model:
+        production_model_mse = 10000
+        if (_MODEL_METRIC_EVAL_KEY in model.tags):
+            production_model_mse = float(model.tags[_MODEL_METRIC_EVAL_KEY])
+
+        if (production_model_mse is None or new_model_mse is None):
+            print("Unable to find", _MODEL_METRIC_EVAL_KEY,
+                  "metrics, exiting evaluation")
+            return False
+
+        print("Current Production model mse: {}, New trained model mse: {}"
+              .format(production_model_mse, new_model_mse))
+
+        if (new_model_mse < production_model_mse):
+            print("New trained model performs better, will be registered")
+            return True
+        else:
+            print("New trained model metric is worse than or equal to "
+                  "production model so skipping model registration.")
+            return False
+
+    else:
+        print("This is the first model, thus it should be registered")
+        return True
+
+
+def main(model_name, step_input, model_upload_folder):
+    print("Running eval_register.py")
+
+    # load context of current run
+    run = Run.get_context()
+    print(vars(run))
+
+    # load the model
+    print("Loading model from " + step_input)
+    model_file = os.path.join(step_input, model_name)
+    model = joblib.load(model_file)
+
+    if not model:
+        print("error: failed to load model")
+        sys.exit(1)
+
+    # not offline - we can register in AML
+    if not run.id.lower().startswith('offlinerun'):
+        print('Get current Azure Machine Learning workspace')
+        ws = run.experiment.workspace
+        print(vars(ws))
+
+        print('Evaluate model with the latest version in workspace')
+        latest_model = get_latest_model(ws, model_name)
+        model_mse = float(run.parent.get_metrics().get(
+            _MODEL_METRIC_EVAL_KEY))
+
+        should_register = evaluate(latest_model, model_mse)
+        if should_register:
+            print('Register to Azure Machine Learning workspace')
+
+            tags = {"area": "diabetes_regression", "mse": model_mse}
+            parent_tags = run.parent.get_tags()
+
+            try:
+                build_id = parent_tags["BuildId"]
+                tags["build_id"] = build_id
+            except KeyError:
+                build_id = None
+                print("BuildId tag not found on parent run.")
+                print("Tags present: {parent_tags}")
+
+            try:
+                build_uri = parent_tags["BuildUri"]
+                tags["build_uri"] = build_uri
+            except KeyError:
+                build_uri = None
+                print("BuildUri tag not found on parent run.")
+                print("Tags present: {parent_tags}")
+
+            # try:
+            #     dataset_id = parent_tags["dataset_id"]
+            # except KeyError:
+            #     dataset_id = None
+            #     print("dataset_id tag not found on parent run.")
+            #     print("Tags present: {parent_tags}")
+
+            # upload model files to run. TODO: set dataset metadata to model
+            run.upload_folder(
+                name=model_upload_folder,
+                path=os.path.abspath(step_input))
+
+            aml_model = run.register_model(
+                model_name=model_name,
+                model_path=model_upload_folder,
+                tags=tags)
+
+            print(vars(aml_model))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='diabetes model evaluation and registration task')
+    parser.add_argument(
+        "--model_name",
+        help="Name of the Model",
+        default="diabetes_model")
+    parser.add_argument(
+        "--step_input",
+        help="Input from previous steps")
+    parser.add_argument(
+        "--model_upload_folder",
+        help="Name of the folder to upload model",
+        default="models")
+    args = parser.parse_args()
+
+    params = vars(args)
+    for i in params:
+        print('{} => {}'.format(i, params[i]))
+
+    main(**params)

--- a/source/training/train.py
+++ b/source/training/train.py
@@ -1,0 +1,122 @@
+"""
+Copyright (C) Microsoft Corporation. All rights reserved.​
+ ​
+Microsoft Corporation (“Microsoft”) grants you a nonexclusive, perpetual,
+royalty-free right to use, copy, and modify the software code provided by us
+("Software Code"). You may not sublicense the Software Code or any use of it
+(except to your affiliates and to vendors to perform work on your behalf)
+through distribution, network access, service agreement, lease, rental, or
+otherwise. This license does not purport to express any claim of ownership over
+data you may have shared with Microsoft in the creation of the Software Code.
+Unless applicable law gives you more rights, Microsoft reserves all other
+rights not expressly granted herein, whether by implication, estoppel or
+otherwise. ​
+ ​
+THE SOFTWARE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+MICROSOFT OR ITS LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THE SOFTWARE CODE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import argparse
+import os
+import joblib
+import pandas as pd
+from sklearn.linear_model import Ridge
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+from azureml.core import Run
+
+
+# Split the dataframe into test and train data
+def split_data(df):
+    X = df.drop('Y', axis=1).values
+    y = df['Y'].values
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=0)
+    data = {"train": {"X": X_train, "y": y_train},
+            "test": {"X": X_test, "y": y_test}}
+    return data
+
+
+# Train the model, return the model
+def train_model(data, ridge_args):
+    reg_model = Ridge(**ridge_args)
+    reg_model.fit(data["train"]["X"], data["train"]["y"])
+    return reg_model
+
+
+# Evaluate the metrics for the model
+def get_model_metrics(model, data):
+    preds = model.predict(data["test"]["X"])
+    mse = mean_squared_error(preds, data["test"]["y"])
+    metrics = {"mse": mse}
+    return metrics
+
+
+def main(model_name, source_data, step_output):
+    print("Running train.py")
+
+    # load context of current run
+    run = Run.get_context()
+    print("current run: {}".format(vars(run)))
+
+    if not run.id.lower().startswith('offlinerun'):
+        print("parent run: {}".format(vars(run.parent)))
+
+    # Define training parameters
+    ridge_args = {"alpha": 0.5}
+
+    # Load the training data as dataframe
+    data_file = os.path.abspath(source_data)
+    train_df = pd.read_csv(data_file)
+    data = split_data(train_df)
+
+    # Train the model
+    model = train_model(data, ridge_args)
+
+    # Log the metrics for the model
+    print("model metrics:")
+    metrics = get_model_metrics(model, data)
+    for (k, v) in metrics.items():
+        print(f"{k}: {v}")
+        # log run metrics for cloud run
+        if not run.id.lower().startswith('offlinerun'):
+            run.log(k, v)
+            run.parent.log(k, v)
+
+    # Pass model file to next step
+    os.makedirs(step_output, exist_ok=True)
+    model_output_path = os.path.join(step_output, model_name)
+    joblib.dump(value=model, filename=model_output_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='diabetes training task')
+    parser.add_argument(
+        "--model_name",
+        help="Name of the Model",
+        default="diabetes_model")
+    parser.add_argument(
+        "--source_data",
+        help="input raw data",
+        default="input")
+    parser.add_argument(
+        "--step_output",
+        help="output for passing data to next step",
+        default="output")
+    args = parser.parse_args()
+
+    params = vars(args)
+    for i in params:
+        print('{} => {}'.format(i, params[i]))
+
+    main(**params)

--- a/source/util/model_helper.py
+++ b/source/util/model_helper.py
@@ -1,0 +1,63 @@
+"""
+model_helper.py
+"""
+from azureml.core.model import Model as AMLModel
+
+
+def get_latest_model(workspace, model_name, tag_name=None, tag_value=None):
+    """
+    Retrieves and returns the latest model from the workspace
+    by its name and (optional) tag.
+
+    Parameters:
+    workspace (Workspace): aml.core Workspace that the model lives.
+    model_name (str): name of the model we are looking for
+    (optional) tag (str): the tag value & name the model was registered under.
+
+    Return:
+    A single aml model from the workspace that matches the name and tag.
+    """
+    try:
+        # Validate params. cannot be None.
+        if model_name is None:
+            raise ValueError("model_name[:str] is required")
+
+        if workspace is None:
+            raise ValueError("No workspace defined.")
+
+        model_list = None
+        tag_ext = ""
+
+        # Get lastest model
+        # True: by name and tags
+        if tag_name is not None and tag_value is not None:
+            model_list = AMLModel.list(
+                workspace, name=model_name,
+                tags=[[tag_name, tag_value]], latest=True
+            )
+            tag_ext = f"tag_name: {tag_name}, tag_value: {tag_value}."
+        # False: Only by name
+        else:
+            model_list = AMLModel.list(
+                workspace, name=model_name, latest=True)
+
+        # latest should only return 1 model, but if it does,
+        # then maybe sdk or source code changed.
+
+        # define the error messages
+        too_many_model_message = ("Found more than one latest model. "
+                                  f"Models found: {model_list}. "
+                                  f"{tag_ext}")
+
+        no_model_found_message = (f"No Model found with name: {model_name}. "
+                                  f"{tag_ext}")
+
+        if len(model_list) > 1:
+            raise ValueError(too_many_model_message)
+        if len(model_list) == 1:
+            return model_list[0]
+        else:
+            print(no_model_found_message)
+            return None
+    except Exception:
+        raise


### PR DESCRIPTION
This is currently a prototype to remove glue codes needed for continuous integration. Specifically:

* CI logic is encapsulated in ML Pipeline
* ML pipeline is defined in a yaml file, .pipelines/ml_training_pipeline.yml
* Source codes for ML pipeline steps are under /source. These are the only codes customers need to provide
* RunConfig and training dependencies are under .azureml folder. Customer can drop their ML workspace config.json and it will work
* Add a new azure pipeline for ML CI: .pipelines/diabetes_regression-ci-yml-pipeline.yml. This azure pipeline uses AzureML CLI and ServerTask only.
