### PR TITLE
Model registration tags come from parameters.json

### DIFF
--- a/diabetes_regression/evaluate/evaluate_model.py
+++ b/diabetes_regression/evaluate/evaluate_model.py
@@ -83,7 +83,7 @@ parser.add_argument(
     "--model_name",
     type=str,
     help="Name of the Model",
-    default="sklearn_regression_model.pkl",
+    default="diabetes_model.pkl",
 )
 
 parser.add_argument(

--- a/diabetes_regression/parameters.json
+++ b/diabetes_regression/parameters.json
@@ -7,6 +7,10 @@
     {
 
     },
+    "registration":
+    {
+        "tags": ["mse"]
+    },
     "scoring":
     {
         

--- a/diabetes_regression/register/register_model.py
+++ b/diabetes_regression/register/register_model.py
@@ -104,7 +104,7 @@ def main():
             mtag = run.parent.get_metrics()[tag]
             model_tags[tag] = mtag
         except KeyError:
-            print("Could not find {tag} metric on parent run.")
+            print(f"Could not find {tag} metric on parent run.")
 
     # load the model
     print("Loading model from " + model_path)
@@ -116,13 +116,13 @@ def main():
     except KeyError:
         build_id = None
         print("BuildId tag not found on parent run.")
-        print("Tags present: {parent_tags}")
+        print(f"Tags present: {parent_tags}")
     try:
         build_uri = parent_tags["BuildUri"]
     except KeyError:
         build_uri = None
         print("BuildUri tag not found on parent run.")
-        print("Tags present: {parent_tags}")
+        print(f"Tags present: {parent_tags}")
 
     if (model is not None):
         dataset_id = parent_tags["dataset_id"]

--- a/diabetes_regression/training/train_aml.py
+++ b/diabetes_regression/training/train_aml.py
@@ -55,7 +55,7 @@ def main():
         "--model_name",
         type=str,
         help="Name of the Model",
-        default="sklearn_regression_model.pkl",
+        default="diabetes_model.pkl",
     )
 
     parser.add_argument(


### PR DESCRIPTION
Added a registration section to parameters.json. If the keys found in the "tags" section are found as tags on the parent run, the tag will be applied to the model. 

The registration doesn't fail if the tag is not found.