### PR TITLE
Fix training/scoring conda deps

### DIFF
--- a/diabetes_regression/conda_dependencies.yml
+++ b/diabetes_regression/conda_dependencies.yml
@@ -18,23 +18,22 @@ name: diabetes_regression_training_env
 dependencies:
   # The python interpreter version.
   # Currently Azure ML Workbench only supports 3.5.2 and later.
-  - python=3.7.5
-  # Required by azureml-defaults, installed separately through Conda to
-  # get a prebuilt version and not require build tools for the install.
-  - psutil=5.6 #latest
+  - python=3.7.*
+  - pip
 
   - pip:
-      # Required packages for AzureML execution, history, and data preparation.
-      - azureml-model-management-sdk==1.0.1b6.post1
-      - azureml-sdk==1.0.74
-      - scipy==1.3.1
-      - scikit-learn==0.22
-      - pandas==0.25.3
-      - numpy==1.17.3
-      - joblib==0.14.0
-      - gunicorn==19.9.0
-      - flask==1.1.1
+      # Base AzureML SDK
+      - azureml-sdk==1.2.*
+
+      # Minimum required for the scoring environment. Must match AzureML SDK version.
+      # https://docs.microsoft.com/en-us/azure/machine-learning/concept-environments
+      - azureml-defaults==1.2.*
+
+      # Training deps
+      - scikit-learn
+
+      # Scoring deps
       - inference-schema[numpy-support]
-      - azure
+
+      # MLOps with R
       - azure-storage-blob
-      - azureml-dataprep


### PR DESCRIPTION
Azure deprecated their top level meta-package which led to a deprecation error. We don't actually need this top level package.

I took the opportunity to clean up the conda deps using the dependency tree.

- Trimmed the package list
- Explicitly list pip to avoid conda warning
- Use azureml-defaults for WebApp dependencies
- Lock azureml-sdk and azureml-defaults versions
- Add comments for dependencies