### PR TITLE
Update CI conda deps to match training/scoring SDK

### DIFF
--- a/diabetes_regression/ci_dependencies.yml
+++ b/diabetes_regression/ci_dependencies.yml
@@ -2,26 +2,27 @@ name: mlopspython_ci
 
 dependencies:
   # The python interpreter version.
-  - python=3.7.5
+  - python=3.7.*
 
   # dependencies with versions aligned with conda_dependencies.yml.
-  - numpy=1.18.1
-  - pandas=1.0.0
-  - scikit-learn=0.22.1
+  - numpy
+  - pandas
+  - scikit-learn
     # dependencies for MLOps with R.
   - r=3.6.0
   - r-essentials=3.6.0
 
-  - pip=20.0.2
+  - pip
+
   - pip:
       # dependencies with versions aligned with conda_dependencies.yml.
-      - azureml-sdk==1.1.5.1
+      - azureml-sdk==1.2.*
 
       # Additional pip dependencies for the CI environment.
-      - pytest==5.3.1
-      - pytest-cov==2.8.1
-      - requests==2.22.0
-      - python-dotenv==0.10.3
-      - flake8==3.7.9
-      - flake8_formatter_junit_xml==0.0.6
-      - azure-cli==2.2.0
+      - pytest
+      - pytest-cov
+      - requests
+      - python-dotenv
+      - flake8
+      - flake8_formatter_junit_xml
+      - azure-cli

--- a/diabetes_regression/ci_dependencies.yml
+++ b/diabetes_regression/ci_dependencies.yml
@@ -5,24 +5,24 @@ dependencies:
   - python=3.7.*
 
   # dependencies with versions aligned with conda_dependencies.yml.
-  - numpy
-  - pandas
-  - scikit-learn
+  - numpy=1.18.*
+  - pandas=1.0.*
+  - scikit-learn=0.22.*
     # dependencies for MLOps with R.
   - r=3.6.0
   - r-essentials=3.6.0
 
-  - pip
+  - pip=20.0.*
 
   - pip:
       # dependencies with versions aligned with conda_dependencies.yml.
       - azureml-sdk==1.2.*
 
       # Additional pip dependencies for the CI environment.
-      - pytest
-      - pytest-cov
-      - requests
-      - python-dotenv
-      - flake8
-      - flake8_formatter_junit_xml
-      - azure-cli
+      - pytest==5.4.*
+      - pytest-cov==2.8.*
+      - requests==2.23.*
+      - python-dotenv==0.12.*
+      - flake8==3.7.*
+      - flake8_formatter_junit_xml==0.0.*
+      - azure-cli==2.3.*


### PR DESCRIPTION
- Tied SDK version to 1.2.x as with conda_dependencies.yml
- Allow deps to fall out based on SDK
- Kept the rest of the deps manually specified to keep image size small and minimize regressions

Passing build at https://aidemos.visualstudio.com/MLOps/_build/results?buildId=4388&view=results

Test image deployed at mcr.microsoft.com/mlops/python:tcare-test