### PR TITLE
Fix docker pipeline by removing trailing whitespace

### DIFF
--- a/environment_setup/docker-image-pipeline.yml
+++ b/environment_setup/docker-image-pipeline.yml
@@ -28,7 +28,7 @@ steps:
       tags: |
        ${{format('build-{0}', '$(Build.BuildNumber)')}}
        ${{format('amlsdk-{0}', '$(amlsdkversion)')}}
-       ${{format('release-{0}', '$(githubrelease)')}}  
+       ${{format('release-{0}', '$(githubrelease)')}}
        latest
       buildContext: '$(Build.SourcesDirectory)' 
       dockerFile: '$(Build.SourcesDirectory)/environment_setup/Dockerfile'


### PR DESCRIPTION
The docker pipeline fails to tag because the trailing whitespace gets included in the tag name.

Successful run at https://aidemos.visualstudio.com/MLOps/_build/results?buildId=4398&view=results
