### PR TITLE
Fix CD deployment break

### DIFF
--- a/.pipelines/diabetes_regression-cd.yml
+++ b/.pipelines/diabetes_regression-cd.yml
@@ -59,7 +59,7 @@ stages:
         inlineScript: |
           set -e # fail on error
           
-          az ml model deploy --name $(ACI_DEPLOYMENT_NAME) --model '$(MODEL_NAME):$(MODEL_VERSION)' \
+          az ml model deploy --name $(ACI_DEPLOYMENT_NAME) --model '$(MODEL_NAME):$(get_model.MODEL_VERSION)' \
           --ic inference_config.yml \
           --dc deployment_config_aci.yml \
           -g $(RESOURCE_GROUP) --workspace-name $(WORKSPACE_NAME) \
@@ -105,7 +105,7 @@ stages:
         inlineScript: |
           set -e # fail on error
           
-          az ml model deploy --name $(AKS_DEPLOYMENT_NAME) --model '$(MODEL_NAME):$(MODEL_VERSION)' \
+          az ml model deploy --name $(AKS_DEPLOYMENT_NAME) --model '$(MODEL_NAME):$(get_model.MODEL_VERSION)' \
           --compute-target $(AKS_COMPUTE_NAME) \
           --ic inference_config.yml \
           --dc deployment_config_aks.yml \
@@ -137,7 +137,7 @@ stages:
         artifactBuildId: ${{ parameters.artifactBuildId }}
     - template: diabetes_regression-package-model-template.yml
       parameters:
-        modelId: $(MODEL_NAME):$(MODEL_VERSION)
+        modelId: $(MODEL_NAME):$(get_model.MODEL_VERSION)
         scoringScriptPath: '$(Build.SourcesDirectory)/$(SOURCES_DIR_TRAIN)/scoring/score.py'
         condaFilePath: '$(Build.SourcesDirectory)/$(SOURCES_DIR_TRAIN)/conda_dependencies.yml'
     - script: echo $(IMAGE_LOCATION) >image_location.txt


### PR DESCRIPTION
Recently the template to get the model version had a name associated with the step that sets the variable. We need to also update the variable references in future steps to use the template step name as a prefix. This resulted in the MODEL_VERSION variable causing failures in each CD deployment step since it was not set.

This did not show up in CI because the MODEL_VERSION var is hard coded in the variable group. We should also remove that.