### PR TITLE
fix TRAIN_SCRIPT_PATH value in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ AML_CLUSTER_PRIORITY = 'lowpriority'
 # Training Config
 MODEL_NAME = 'diabetes_regression_model.pkl'
 MODEL_VERSION = '1'
-TRAIN_SCRIPT_PATH = 'training/train.py'
+TRAIN_SCRIPT_PATH = 'training/train_aml.py'
 
 
 # AML Pipeline Config


### PR DESCRIPTION
TRAIN_SCRIPT_PATH value updated from 'training/train.py' to 'training/train_aml.py'.

This is aligned with /.pipelines/diabetes_regression-variables-template.yml.