### PR TITLE
development_setup.md update

### DIFF
--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -27,7 +27,7 @@ export BUILD_BUILDID=$(uuidgen); python ml_service/pipelines/diabetes_regression
 ```
 
 BUILD_BUILDID is a variable used to uniquely identify the ML pipeline between the
-`build_train_pipeline.py` and `run_train_pipeline.py` scripts. In Azure DevOps it is
+`diabetes_regression_build_train_pipeline.py` and `run_train_pipeline.py` scripts. In Azure DevOps it is
 set to the current build number. In a local environment, we can use a command such as
 `uuidgen` so set a different random identifier on each run, ensuring there are 
 no collisions.

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -12,18 +12,10 @@ In order to configure the project locally, create a copy of `.env.example` in th
 
 Install [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html). 
 
-Install the required Python modules. 
+Install the required Python modules. [`install_requirements.sh`](https://github.com/microsoft/MLOpsPython/blob/master/environment_setup/install_requirements.sh) creates and activates a new conda environment with required Python modules.
 
 ```
 . environment_setup/install_requirements.sh 
-```
-
-`install_requirements.sh` create and activate a new conda environment with required Python modules.
-
-```
-conda env create -f diabetes_regression/ci_dependencies.yml
-
-conda activate mlopspython_ci
 ```
 
 ### Running local code

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -10,19 +10,20 @@ In order to configure the project locally, create a copy of `.env.example` in th
 
 [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli). The Azure CLI will be used to log you in interactively.
 
-Create a virtual environment using [venv](https://docs.python.org/3/library/venv.html), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) or [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv). 
+Install [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html). 
 
-Here is an example for setting up and activating a `venv` environment with Python 3:
-
-```
-python3 -mvenv .venv
-source .venv/bin/activate
-```
-
-Install the required Python modules in your virtual environment.
+Install the required Python modules. 
 
 ```
-pip install -r environment_setup/requirements.txt 
+. environment_setup/install_requirements.sh 
+```
+
+`install_requirements.sh` create and activate a new conda environment with required Python modules.
+
+```
+conda env create -f diabetes_regression/ci_dependencies.yml
+
+conda activate mlopspython_ci
 ```
 
 ### Running local code

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -23,7 +23,7 @@ Install the required Python modules. [`install_requirements.sh`](https://github.
 To run your local ML pipeline code on Azure ML, run a command such as the following (in bash, all on one line):
 
 ```
-export BUILD_BUILDID=$(uuidgen); python ml_service/pipelines/build_train_pipeline.py && python ml_service/pipelines/run_train_pipeline.py
+export BUILD_BUILDID=$(uuidgen); python ml_service/pipelines/diabetes_regression_build_train_pipeline.py && python ml_service/pipelines/run_train_pipeline.py
 ```
 
 BUILD_BUILDID is a variable used to uniquely identify the ML pipeline between the


### PR DESCRIPTION
development_setup.md updated to use install_requirements.sh.

See #158:

> Use conda rather than pip packages when possible (as recommended in AML docs).
> Dev environment is hence also constrained to conda (no more pip install -r requirements.txt).