### PR TITLE
Improve readability of exceptions in build pipeline script

### DIFF
--- a/ml_service/util/attach_compute.py
+++ b/ml_service/util/attach_compute.py
@@ -1,4 +1,5 @@
 
+import traceback
 from azureml.core import Workspace
 from azureml.core.compute import AmlCompute
 from azureml.core.compute import ComputeTarget
@@ -33,6 +34,6 @@ def get_compute(workspace: Workspace, compute_name: str, vm_size: str, for_batch
             )
         return compute_target
     except ComputeTargetException as ex:
-        print(ex)
+        traceback.print_exc()
         print("An error occurred trying to provision compute.")
         exit(1)

--- a/ml_service/util/manage_environment.py
+++ b/ml_service/util/manage_environment.py
@@ -1,5 +1,6 @@
 
 import os
+import traceback
 from azureml.core import Workspace, Environment
 from ml_service.util.env_variables import Env
 from azureml.core.runconfig import DEFAULT_CPU_IMAGE, DEFAULT_GPU_IMAGE
@@ -36,5 +37,5 @@ def get_environment(
             print(restored_environment)
         return restored_environment
     except Exception as e:
-        print(e)
+        traceback.print_exc()
         exit(1)


### PR DESCRIPTION
Previously exceptions were caught and printed without using the traceback, leading to uninformative exceptions that are hard to debug.
This PR uses the traceback module to print out the exception traceback instead.