### PR TITLE
Update train.py

### DIFF
--- a/diabetes_regression/training/train.py
+++ b/diabetes_regression/training/train.py
@@ -53,7 +53,7 @@ def train_model(data, ridge_args):
 # Evaluate the metrics for the model
 def get_model_metrics(model, data):
     preds = model.predict(data["test"]["X"])
-    mse = mean_squared_error(preds, data["test"]["y"])
+    mse = mean_squared_error(data["test"]["y"],preds)
     metrics = {"mse": mse}
     return metrics
 


### PR DESCRIPTION
The order of y_true, y_pred is reversed
sklearn.metrics.mean_squared_error(y_true, y_pred, *, sample_weight=None, multioutput='uniform_average', squared=True)