### PR TITLE
Allow generation of HTML Code Coverage reports

### DIFF
--- a/.pipelines/code-quality-template.yml
+++ b/.pipelines/code-quality-template.yml
@@ -17,9 +17,17 @@ steps:
     failTaskOnFailedTests: true
   displayName: 'Publish test results'
 
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK'
+  inputs:
+    version: 3.1.x
+    performMultiLevelLookup: true
+
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish coverage report'
   condition: succeededOrFailed()
+  env:
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1'
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: 'coverage.xml'


### PR DESCRIPTION
Currently when running this pipeline a message 
##[warning]Please install dotnet core to enable automatic generation of Html report.
is displayed under code coverage.

This fix adds an addiitonal task to install .Net Core SDK as well as set the environment variable DOTNET_SYSTEM_GLOBALIZATION_INVARIANT to 1 for the publish coverage report task.
A new warning will now be shown-
##[warning]Ignoring coverage report directory with Html content as we are auto-generating Html content

However now if you view the code coverage report it is HTML generated and looks a lot better than before